### PR TITLE
package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "purus-wp",
+  "version": "1.0.0",
+  "description": "Minimalistic WordPress theme.",
+  "main": "index.php",
+  "dependencies": {},
+  "devDependencies": {
+    "gulp": "^3.9.1",
+    "gulp-cssnext": "^1.0.1",
+    "gulp-postcss": "^6.1.1",
+    "gulp-requirejs": "^0.1.3",
+    "gulp-sass": "^2.3.2",
+    "gulp-sourcemaps": "^1.6.0",
+    "gulp-uglify": "^1.5.4"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Prelc/Purus-WP.git"
+  },
+  "keywords": [
+    "wp",
+    "wordpress",
+    "purus",
+    "php",
+    "js",
+    "css",
+    "theme"
+  ],
+  "author": "Marko Prelec",
+  "license": "GPL-2.0+",
+  "bugs": {
+    "url": "https://github.com/Prelc/Purus-WP/issues"
+  },
+  "homepage": "https://github.com/Prelc/Purus-WP#readme"
+}

--- a/package.json
+++ b/package.json
@@ -5,13 +5,15 @@
   "main": "index.php",
   "dependencies": {},
   "devDependencies": {
+    "autoprefixer": "^6.3.6",
     "gulp": "^3.9.1",
     "gulp-cssnext": "^1.0.1",
     "gulp-postcss": "^6.1.1",
     "gulp-requirejs": "^0.1.3",
     "gulp-sass": "^2.3.2",
     "gulp-sourcemaps": "^1.6.0",
-    "gulp-uglify": "^1.5.4"
+    "gulp-uglify": "^1.5.4",
+    "precss": "^1.4.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
`package.json` is needed for other developers, because they need to install the npm packages first that the gulp works for them.
